### PR TITLE
Fix the Scunthorpe problem.

### DIFF
--- a/src/main/java/me/botsko/darmok/chatter/Censor.java
+++ b/src/main/java/me/botsko/darmok/chatter/Censor.java
@@ -115,7 +115,7 @@ public class Censor {
 		for(String variation : variations){
 			// scan for illegal words
 			for(String w : rejectWords){
-				if(variation.contains(w)){
+				if(variation.matches("\b"+w+"\b")){
 					return true;
 				}
 			}
@@ -131,7 +131,7 @@ public class Censor {
 	 */
 	public String replaceCensoredWords( String msg ){
 		for(String w : censorWords){
-			msg = msg.replaceAll("(?i)"+w, "*****");
+			msg = msg.replaceAll("(?i)\b"+w+"\b", "*****");
 		}
 		return msg;
 	}


### PR DESCRIPTION
The Scunthorpe problem is a problem where a filter blocks an innocent word because one of its words includes a illegal word (e.g., S*cunt*horpe). I fixed the problem by adding word boundaries (\b characters) before and after the word.